### PR TITLE
Address lookup result type

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlin.mpp.stability.nowarn=true
 kotlin.native.ignoreDisabledTargets=true
 # Publishing
 group=org.drewcarlson
-version=0.1.2-SNAPSHOT
+version=0.1.4-SNAPSHOT
 mavenUrl=https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/
 mavenSnapshotUrl=https://s01.oss.sonatype.org/content/repositories/snapshots/
 pomProjectUrl=https://github.com/DrewCarlson/Blockset-Kotlin

--- a/src/commonMain/kotlin/BdbService.kt
+++ b/src/commonMain/kotlin/BdbService.kt
@@ -145,10 +145,10 @@ interface BdbService {
     public suspend fun addressLookup(
         domainName: String,
         vararg currencyCodes: String
-    ): BdbAddresses
+    ): BdbAddressesResult
 
     public suspend fun addressLookup(
         domainName: String,
         currencyCodeList: List<String>
-    ): BdbAddresses
+    ): BdbAddressesResult
 }

--- a/src/commonMain/kotlin/model/BdbAddresses.kt
+++ b/src/commonMain/kotlin/model/BdbAddresses.kt
@@ -3,17 +3,24 @@ package drewcarlson.blockset
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
+sealed class BdbAddressesResult
+
 @Serializable
 data class BdbAddresses(
     @SerialName("_embedded")
     val embedded: Embedded,
-) {
+) : BdbAddressesResult() {
 
     @Serializable
     data class Embedded(
         val addresses: List<BdbAddress>
     )
 }
+
+data class BdbAddressesError(
+    val status: Int,
+    val body: String?,
+) : BdbAddressesResult()
 
 @Serializable
 data class BdbAddress(

--- a/src/commonTest/kotlin/BlocksetTests.kt
+++ b/src/commonTest/kotlin/BlocksetTests.kt
@@ -38,7 +38,8 @@ class BlocksetTests {
 
     @Test
     fun testAddressLookup() = runBlocking {
-        val addresses = bdbService.addressLookup("ijustine.eth", "eth").embedded.addresses
+        val result = bdbService.addressLookup("ijustine.eth", "eth")
+        val addresses = (result as BdbAddresses).embedded.addresses
         assertEquals(BdbAddress.Status.SUCCESS, addresses.first().status)
     }
 }


### PR DESCRIPTION
Consumes all exceptions raised below the `BdbService` interface to avoid crashes or explicit exception handling around address lookup calls.